### PR TITLE
Compatibility with GHC 7.10

### DIFF
--- a/RepLib/Generics/RepLib/Lib.hs
+++ b/RepLib/Generics/RepLib/Lib.hs
@@ -10,7 +10,6 @@
 -- License     :  BSD
 --
 -- Maintainer  :  sweirich@cis.upenn.edu
--- Stability   :  experimental
 -- Portability :  non-portable
 --
 -- A library of type-indexed functions
@@ -336,10 +335,10 @@ class Rep1 (LreduceD b) a => Lreduce b a where
 
 -- For example
 -- @ instance Fold [] where
---	 foldRight op = rreduceR1 (rList1 (RreduceD { rreduceD = op })
---					  (RreduceD { rreduceD = foldRight op }))
---	 foldLeft op = lreduceR1 (rList1 (LreduceD  { lreduceD = op })
---					 (LreduceD { lreduceD = foldLeft op }))
+--    foldRight op = rreduceR1 (rList1 (RreduceD { rreduceD = op })
+--                             (RreduceD { rreduceD = foldRight op }))
+--    foldLeft op = lreduceR1 (rList1 (LreduceD  { lreduceD = op })
+--                            (LreduceD { lreduceD = foldLeft op }))
 -- @
 
 instance Rreduce b a => Sat (RreduceD b a) where
@@ -382,8 +381,8 @@ instance (Ord a, Rreduce b a) => Rreduce b (Set a) where
 -- | All of the functions below are defined using instances
 -- of the following class
 class Fold f where
-	 foldRight :: Rep a => (a -> b -> b) -> f a -> b -> b
-	 foldLeft  :: Rep a => (b -> a -> b) -> b -> f a -> b
+  foldRight :: Rep a => (a -> b -> b) -> f a -> b -> b
+  foldLeft  :: Rep a => (b -> a -> b) -> b -> f a -> b
 
 -- | Fold a bindary operation left over a datastructure
 crush      :: (Rep a, Fold t) => (a -> a -> a) -> a -> t a -> a
@@ -432,14 +431,14 @@ gelem x t  = foldRight (\a b -> a == x || b) t False
 
 
 instance Fold [] where
-	 foldRight op = rreduceR1 (rList1 (RreduceD { rreduceD = op })
-					  (RreduceD { rreduceD = foldRight op }))
-	 foldLeft op = lreduceR1 (rList1 (LreduceD  { lreduceD = op })
-					 (LreduceD { lreduceD = foldLeft op }))
+  foldRight op = rreduceR1 (rList1 (RreduceD { rreduceD = op })
+                           (RreduceD { rreduceD = foldRight op }))
+  foldLeft op = lreduceR1 (rList1 (LreduceD  { lreduceD = op })
+                          (LreduceD { lreduceD = foldLeft op }))
 
 instance Fold Set where
-	 foldRight op x b = foldRight op (Set.toList x) b
-	 foldLeft op b x = foldLeft op b (Set.toList x)
+  foldRight op x b = foldRight op (Set.toList x) b
+  foldLeft op b x = foldLeft op b (Set.toList x)
 
 instance Fold (Map k) where
   foldRight op x b = foldRight op (Map.elems x) b

--- a/RepLib/Generics/RepLib/PreludeLib.hs
+++ b/RepLib/Generics/RepLib/PreludeLib.hs
@@ -36,7 +36,7 @@
 --   >
 --   > instance Show T where
 --   >   showsPrec = showsPrecR1 rep1   -- showsPrecR1 is defined in this module
-													 --
+--
 --  * This library also serves as a model for generic functions that are
 -- slight modifications to these prelude operations. For example, if you
 -- wanted to define reverse lexicographic ordering or an XML pretty
@@ -153,14 +153,14 @@ maxBoundR1 r1     = error ("maxBoundR1 not supported for " ++ show r1)
 data ShowD a = ShowD { showsPrecD :: Int -> a -> ShowS }
 
 instance Show a => Sat (ShowD a) where
-	 dict = ShowD { showsPrecD = showsPrec }
+  dict = ShowD { showsPrecD = showsPrec }
 
 getFixity :: Emb a b -> Int
 getFixity c = case fixity c of
-				    Nonfix   -> 0
-				    Infix  i -> i
-				    Infixl i -> i
-				    Infixr i -> i
+               Nonfix   -> 0
+               Infix  i -> i
+               Infixl i -> i
+               Infixr i -> i
 
 -- | Minimal completion of the show class
 showsPrecR1 :: R1 ShowD a ->
@@ -168,13 +168,13 @@ showsPrecR1 :: R1 ShowD a ->
                a    -> -- value to be shown
                ShowS
 showsPrecR1 (Data1 (DT _ _) cons) = \p v ->
-	case (findCon cons v) of
+    case (findCon cons v) of
       Val c rec kids ->
           case (labels c) of
             Just labs -> par $ showString (name c) .
                                showString "{" .
-	 		       showRecord rec kids labs .
-			       showString "}"
+                               showRecord rec kids labs .
+                               showString "}"
             Nothing   -> par $ showString (name c) .
                                maybespace .
                                showKids rec kids
@@ -191,7 +191,7 @@ showsPrecR1 (Data1 (DT _ _) cons) = \p v ->
                 showRecord (r :+: rs) (a :*: aa) (l : ls) =
                     showString l . ('=':) . showKid r a . showString (", ") . showRecord rs aa ls
                 showRecord _ _ _ = error ("Incorrect representation: " ++
-				          "wrong number of labels in record type")
+                                          "wrong number of labels in record type")
 
                 showKids :: MTup ShowD l -> l -> ShowS
                 showKids MNil Nil = id

--- a/RepLib/Generics/RepLib/R.hs
+++ b/RepLib/Generics/RepLib/R.hs
@@ -139,7 +139,7 @@ instance (Rep a, Rep b) => Rep (a :=: b) where rep = Equal rep rep
 rUnitEmb :: Emb Nil ()
 rUnitEmb = Emb { to = \Nil -> (),
                  from = \() -> Just Nil,
-			        labels = Nothing,
+                 labels = Nothing,
                  name = "()",
                  fixity = Nonfix }
 
@@ -156,7 +156,7 @@ instance (Rep a, Rep b) => Rep (a,b) where
 
 rTup2 :: forall a b. (Rep a, Rep b) => R (a,b)
 rTup2 = let args =  ((rep :: R a) :+: (rep :: R b) :+: MNil) in
-			Data (DT "(,)" args) [ Con rPairEmb args ]
+            Data (DT "(,)" args) [ Con rPairEmb args ]
 
 rPairEmb :: Emb (a :*: b :*: Nil) (a,b)
 rPairEmb =
@@ -179,7 +179,7 @@ rNilEmb = Emb {   to   = \Nil -> [],
                            []    -> Just Nil,
                   labels = Nothing,
                   name = "[]",
-		  fixity = Nonfix
+                  fixity = Nonfix
                  }
 
 rConsEmb :: Emb (a :*: [a] :*: Nil) [a]
@@ -191,7 +191,7 @@ rConsEmb =
                     []        -> Nothing,
             labels = Nothing,
             name = ":",
-	    fixity = Nonfix -- ???
+            fixity = Nonfix -- ???
           }
 
 instance Rep a => Rep [a] where

--- a/RepLib/Generics/RepLib/RepAux.hs
+++ b/RepLib/Generics/RepLib/RepAux.hs
@@ -280,8 +280,9 @@ type Query r = forall a. Rep a => a -> r
 gmapQ :: forall a r. Rep a => Query r -> a -> [r]
 gmapQ q =
   case (rep :: R a) of
-    (Data _ cons) -> \x -> case (findCon cons x) of
-		Val _ reps ys -> mapQ_l (const q) reps ys
+    (Data _ cons) -> \x ->
+      case (findCon cons x) of
+       Val _ reps ys -> mapQ_l (const q) reps ys
     _ -> const []
 
 
@@ -290,9 +291,10 @@ type MapM m = forall a. Rep a => a -> m a
 
 gmapM   :: forall a m. (Rep a, Monad m) => MapM m -> a -> m a
 gmapM m = case (rep :: R a) of
-   (Data _ cons) -> \x -> case (findCon cons x) of
-     Val emb reps ys -> do l <- mapM_l (const m) reps ys
-                           return (to emb l)
+   (Data _ cons) -> \x ->
+     case (findCon cons x) of
+      Val emb reps ys -> do l <- mapM_l (const m) reps ys
+                            return (to emb l)
    _ -> return
 
 
@@ -311,16 +313,18 @@ type Query1 ctx r = forall a. Rep a => ctx a -> a -> r
 gmapQ1 :: forall a ctx r. (Rep1 ctx a) => Query1 ctx r -> a -> [r]
 gmapQ1 q  =
   case (rep1 :: R1 ctx a) of
-    (Data1 _ cons) -> \x -> case (findCon cons x) of
-		Val _ recs kids -> mapQ_l q recs kids
+    (Data1 _ cons) -> \x ->
+      case (findCon cons x) of
+       Val _ recs kids -> mapQ_l q recs kids
     _ -> const []
 
 type MapM1 ctx m = forall a. Rep a => ctx a -> a -> m a
 gmapM1  :: forall a ctx m. (Rep1 ctx a, Monad m) => MapM1 ctx m -> a -> m a
 gmapM1 m = case (rep1 :: R1 ctx a) of
-   (Data1 _ cons) -> \x -> case (findCon cons x) of
-     Val emb rec ys -> do l <- mapM_l m rec ys
-                          return (to emb l)
+   (Data1 _ cons) -> \x ->
+     case (findCon cons x) of
+      Val emb rec ys -> do l <- mapM_l m rec ys
+                           return (to emb l)
    _ -> return
 
 -------------- Spine from SYB Reloaded ---------------------------
@@ -329,20 +333,20 @@ data Typed a = a ::: R a
 infixr 7 :::
 
 data Spine a where
-	 Constr :: a -> Spine a
-	 (:<>)  :: Spine (a -> b) -> Typed a -> Spine b
+  Constr :: a -> Spine a
+  (:<>)  :: Spine (a -> b) -> Typed a -> Spine b
 
 toSpineR :: R a -> a -> Spine a
 toSpineR (Data _ cons) a =
-	 case (findCon cons a) of
-	    Val emb reps kids -> toSpineRl reps kids (to emb)
+  case (findCon cons a) of
+   Val emb reps kids -> toSpineRl reps kids (to emb)
 toSpineR _ a = Constr a
 
 toSpineRl :: MTup R l -> l -> (l -> a) -> Spine a
 toSpineRl MNil Nil into = Constr (into Nil)
 toSpineRl (ra :+: rs) (a :*: l) into =
-	 (toSpineRl rs l into') :<> (a ::: ra)
-		  where into' tl1 x1 = into (x1 :*: tl1)
+  (toSpineRl rs l into') :<> (a ::: ra)
+   where into' tl1 x1 = into (x1 :*: tl1)
 
 toSpine :: Rep a => a -> Spine a
 toSpine = toSpineR rep

--- a/RepLib/Generics/RepLib/SYB/Aliases.hs
+++ b/RepLib/Generics/RepLib/SYB/Aliases.hs
@@ -19,36 +19,36 @@
 -----------------------------------------------------------------------------
 module Generics.RepLib.SYB.Aliases (
 
-	-- * Combinators to \"make\" generic functions via cast
-	mkT, mkQ, mkM, mkMp, mkR,
-	ext0, extT, extQ, extM, extMp, extB, extR,
+   -- * Combinators to \"make\" generic functions via cast
+   mkT, mkQ, mkM, mkMp, mkR,
+   ext0, extT, extQ, extM, extMp, extB, extR,
 
-	-- * Type synonyms for generic function types
-	GenericT,
-	GenericQ,
-	GenericM,
-	GenericB,
-	GenericR,
+   -- * Type synonyms for generic function types
+   GenericT,
+   GenericQ,
+   GenericM,
+   GenericB,
+   GenericR,
    Generic,
    Generic'(..),
    GenericT'(..),
    GenericQ'(..),
    GenericM'(..),
 
-	-- * Inredients of generic functions
-	orElse,
+   -- * Inredients of generic functions
+   orElse,
 
-	-- * Function combinators on generic functions
-	recoverMp,
-	recoverQ,
-	choiceMp,
-	choiceQ
+   -- * Function combinators on generic functions
+   recoverMp,
+   recoverQ,
+   choiceMp,
+   choiceQ
 
-	-- * Type extension for unary type constructors
---	ext1T,
---	ext1M,
---	ext1Q,
---	ext1R
+   -- * Type extension for unary type constructors
+-- ext1T,
+-- ext1M,
+-- ext1Q,
+-- ext1R
 
   ) where
 
@@ -62,8 +62,8 @@ import Generics.RepLib.RepAux
 
 ------------------------------------------------------------------------------
 --
---	Combinators to "make" generic functions
---	We use type-safe cast in a number of ways to make generic functions.
+-- Combinators to "make" generic functions
+-- We use type-safe cast in a number of ways to make generic functions.
 --
 ------------------------------------------------------------------------------
 
@@ -209,7 +209,7 @@ extR def ext = unR ((R def) `ext0` (R ext))
 
 ------------------------------------------------------------------------------
 --
---	Type synonyms for generic function types
+-- Type synonyms for generic function types
 --
 ------------------------------------------------------------------------------
 
@@ -258,9 +258,9 @@ data Generic' c = Generic' { unGeneric' :: Generic c }
 
 
 -- | Other first-class polymorphic wrappers
-newtype GenericT'   = GT { unGT :: Rep a => a -> a }
+newtype GenericT'   = GT { unGT :: forall a. Rep a => a -> a }
 newtype GenericQ' r = GQ { unGQ :: GenericQ r }
-newtype GenericM' m = GM { unGM :: Rep a => a -> m a }
+newtype GenericM' m = GM { unGM :: forall a. Rep a => a -> m a }
 
 
 -- | Left-biased choice on maybies
@@ -305,7 +305,7 @@ recoverQ r f = f `choiceQ` const (return r)
 
 ------------------------------------------------------------------------------
 --
---	Type extension for unary type constructors
+-- Type extension for unary type constructors
 --
 ------------------------------------------------------------------------------
 
@@ -355,7 +355,7 @@ ext1R def ext = unR ((R def) `ext1` (R ext))
 
 ------------------------------------------------------------------------------
 --
---	Type constructors for type-level lambdas
+-- Type constructors for type-level lambdas
 --
 ------------------------------------------------------------------------------
 

--- a/RepLib/Generics/RepLib/SYB/Schemes.hs
+++ b/RepLib/Generics/RepLib/SYB/Schemes.hs
@@ -26,17 +26,17 @@ module Generics.RepLib.SYB.Schemes (
    everywhereBut,
    everywhereM,
 --   somewhere,
-	everything,
-	listify,
+   everything,
+   listify,
    something,
-	synthesize,
-	gsize,
-	glength,
-	gdepth,
-	gcount,
-	gnodecount,
-	gtypecount,
-	gfindtype
+   synthesize,
+   gsize,
+   glength,
+   gdepth,
+   gcount,
+   gnodecount,
+   gtypecount,
+   gfindtype
 
  ) where
 

--- a/RepLib/RepLib.cabal
+++ b/RepLib/RepLib.cabal
@@ -1,5 +1,5 @@
 name:           RepLib
-version:        0.5.3.3
+version:        0.5.3.4
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
@@ -26,9 +26,10 @@ Source-repository head
 
 Library
   build-depends: base >= 4.3 && < 5,
-                 template-haskell >= 2.4 && < 2.10,
+                 template-haskell >= 2.4 && < 2.11,
                  mtl >= 2.0 && < 2.3,
-                 containers >= 0.4 && < 0.6
+                 containers >= 0.4 && < 0.6,
+                 transformers
 
   if impl(ghc < 7.8)
     build-depends: type-equality >= 0.1.0.2 && < 0.2

--- a/Unbound/Unbound/LocallyNameless/Alpha.hs
+++ b/Unbound/Unbound/LocallyNameless/Alpha.hs
@@ -336,13 +336,13 @@ data AlphaD a = AlphaD {
   isTermD   :: a -> Bool,
   isEmbedD  :: a -> Bool,
   swapsD    :: AlphaCtx -> Perm AnyName -> a -> a,
-  fvD       :: Collection f => AlphaCtx -> a -> f AnyName,
-  freshenD  :: Fresh m => AlphaCtx -> a -> m (a, Perm AnyName),
-  lfreshenD :: LFresh m => AlphaCtx -> a -> (a -> Perm AnyName -> m b) -> m b,
+  fvD       :: forall f. Collection f => AlphaCtx -> a -> f AnyName,
+  freshenD  :: forall m. Fresh m => AlphaCtx -> a -> m (a, Perm AnyName),
+  lfreshenD :: forall m b. LFresh m => AlphaCtx -> a -> (a -> Perm AnyName -> m b) -> m b,
   aeqD      :: AlphaCtx -> a -> a -> Bool,
   acompareD :: AlphaCtx -> a -> a -> Ordering,
-  closeD    :: Alpha b => AlphaCtx -> b -> a -> a,
-  openD     :: Alpha b => AlphaCtx -> b -> a -> a,
+  closeD    :: forall b. Alpha b => AlphaCtx -> b -> a -> a,
+  openD     :: forall b. Alpha b => AlphaCtx -> b -> a -> a,
   findpatD  :: a -> AnyName -> FindResult,
   nthpatD   :: a -> NthCont
   }

--- a/Unbound/Unbound/Util.hs
+++ b/Unbound/Unbound/Util.hs
@@ -80,7 +80,8 @@ instance Collection [] where
 newtype Multiset a = Multiset (M.Map a Int)
 
 instance F.Foldable Multiset where
-  fold (Multiset m) = M.foldrWithKey (\a n x -> mconcat (x : replicate n a)) mempty m
+  fold      (Multiset m) = M.foldrWithKey (\a n x -> mconcat (x : replicate n a)) mempty m
+  foldMap f (Multiset m) = M.foldrWithKey (\a n x -> mconcat (x : replicate n (f a))) mempty m
 
 -- | Multisets are containers which preserve multiplicity but not
 --   ordering.

--- a/Unbound/unbound.cabal
+++ b/Unbound/unbound.cabal
@@ -1,5 +1,5 @@
 name:           unbound
-version:        0.4.3.1
+version:        0.4.3.2
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple

--- a/Unbound/unbound.cabal
+++ b/Unbound/unbound.cabal
@@ -1,5 +1,5 @@
 name:           unbound
-version:        0.4.3.2
+version:        0.4.4
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple


### PR DESCRIPTION
This patch makes RepLib and Unbound compatible with a wider range of versions:
- The RepLib/Derive module has been updated to work with template-haskell-2.10.0.
- Both RepLib and Unbound have been updated to work with the new transformers' ExceptT transformer, available from version 0.4 on. Without it, many warnings are shown.
I have checked that everything compiles fine on GHC 7.10, and made all changes conditional on either the GHC, template-haskell or transformers version, so backwards compatibility should not suffer. Said so, I have *not* checked that this still works in GHC < 7.10.