### PR TITLE
Use correct case for Examples directory

### DIFF
--- a/Unbound/unbound.cabal
+++ b/Unbound/unbound.cabal
@@ -20,7 +20,7 @@ homepage:       https://github.com/sweirich/replib
 category:       Language, Generics, Compilers/Interpreters
 extra-source-files: README,
                     CHANGES,
-                    examples/*.hs,
+                    Examples/*.hs,
                     tutorial/Makefile,
                     tutorial/Tutorial.lhs,
                     test/*.hs


### PR DESCRIPTION
cabal is picky on Linux